### PR TITLE
feat(reflection): native get_indexes for SQLite + PostgreSQL

### DIFF
--- a/src/sqlalchemy_adbc/postgresql.py
+++ b/src/sqlalchemy_adbc/postgresql.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import quote
 
+from sqlalchemy.engine.interfaces import ReflectedIndex
 from sqlalchemy.engine.url import URL
 
 from sqlalchemy_adbc.base import ADBCDialect
@@ -44,3 +45,68 @@ class ADBCPostgreSQLDialect(ADBCDialect):
         if url.query:
             kwargs["db_kwargs"] = dict(url.query)
         return [uri], kwargs
+
+    # ── Index reflection ─────────────────────────────────────────────
+    #
+    # ADBC GetObjects doesn't carry per-index column lists, so we query
+    # ``pg_index`` / ``pg_class`` / ``pg_attribute`` directly. The PK
+    # index is excluded here because ``get_pk_constraint`` already
+    # surfaces it via the constraint path; including it would double-
+    # count. Unique-constraint indexes stay — SQLAlchemy's convention
+    # is that unique *indexes* show up in ``get_indexes`` and unique
+    # *constraints* in ``get_unique_constraints`` (a DB may have one,
+    # the other, or both for the same column set).
+
+    def get_indexes(
+        self, connection: Any, table_name: str, schema: str | None = None, **kw: Any
+    ) -> list[ReflectedIndex]:
+        dbapi = self._adbc_connection(connection)
+        cursor = dbapi.cursor()
+        try:
+            # Use LATERAL unnest to expand indkey into one row per column
+            # while preserving column order (WITH ORDINALITY). The COALESCE
+            # on the schema filter lets the caller pass None for "any
+            # schema in the search_path" — matches SQLAlchemy's convention.
+            sql = """
+            SELECT
+                i.relname AS index_name,
+                array_agg(a.attname ORDER BY x.n) AS column_names,
+                ix.indisunique AS is_unique
+            FROM pg_catalog.pg_index ix
+            JOIN pg_catalog.pg_class i ON i.oid = ix.indexrelid
+            JOIN pg_catalog.pg_class t ON t.oid = ix.indrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+            CROSS JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS x(attnum, n)
+            LEFT JOIN pg_catalog.pg_attribute a
+                ON a.attrelid = t.oid AND a.attnum = x.attnum
+            WHERE t.relname = $1
+              AND ($2::text IS NULL OR n.nspname = $2)
+              AND NOT ix.indisprimary
+            GROUP BY i.relname, ix.indisunique
+            ORDER BY i.relname
+            """
+            cursor.execute(sql, (table_name, schema))
+            rows = cursor.fetchall()
+            return [
+                {
+                    "name": row[0],
+                    "column_names": _to_list(row[1]),
+                    "unique": bool(row[2]),
+                }
+                for row in rows
+            ]
+        finally:
+            cursor.close()
+
+
+def _to_list(value: Any) -> list[Any]:
+    """Normalize a column-names aggregate to a plain Python list.
+
+    ADBC Postgres returns ``array_agg(...)`` results through pyarrow;
+    depending on driver version the Python-level value can be a
+    ``list``, a ``tuple``, or a ``pyarrow.Array``. Iteration works on
+    all three, and handles the ``None`` (empty aggregate) case.
+    """
+    if value is None:
+        return []
+    return list(value)

--- a/src/sqlalchemy_adbc/sqlite.py
+++ b/src/sqlalchemy_adbc/sqlite.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy.engine.interfaces import ReflectedIndex
 from sqlalchemy.engine.url import URL
 
 from sqlalchemy_adbc.base import ADBCDialect
@@ -25,3 +26,68 @@ class ADBCSQLiteDialect(ADBCDialect):
         if url.query:
             kwargs["db_kwargs"] = dict(url.query)
         return [], kwargs
+
+    # ── Index reflection ─────────────────────────────────────────────
+    #
+    # ADBC GetObjects lists SQLite indexes as entries with
+    # ``table_type='index'`` but doesn't carry their column lists, so
+    # we query the native catalog (``PRAGMA index_list`` +
+    # ``PRAGMA index_info``) directly. ``sqlite_autoindex_*`` entries
+    # are auto-generated for PRIMARY KEY / UNIQUE constraints and are
+    # already surfaced via ``get_pk_constraint`` / ``get_unique_constraints``
+    # — skip them to match SQLAlchemy's built-in sqlite dialect behavior.
+
+    def get_indexes(
+        self, connection: Any, table_name: str, schema: str | None = None, **kw: Any
+    ) -> list[ReflectedIndex]:
+        dbapi = self._adbc_connection(connection)
+        cursor = dbapi.cursor()
+        try:
+            # PRAGMA statements cannot be parameterized — SQLite ignores
+            # placeholders in that context and would execute the literal
+            # "?" as part of the name. Escape identifiers manually:
+            # double-quote and double any internal double-quotes per the
+            # SQL-92 identifier rule.
+            tbl = _sqlite_ident(table_name)
+            cursor.execute(f"PRAGMA index_list({tbl})")
+            # index_list rows: (seq, name, unique, origin, partial)
+            listings = cursor.fetchall()
+            out: list[ReflectedIndex] = []
+            for row in listings:
+                name = row[1]
+                is_unique = bool(row[2])
+                # SQLite auto-creates an index for every PRIMARY KEY and
+                # for some UNIQUE constraints; those are named
+                # ``sqlite_autoindex_<table>_<N>`` and are better reached
+                # via ``get_pk_constraint``/``get_unique_constraints``.
+                # User-created unique indexes (CREATE UNIQUE INDEX ...)
+                # DO belong here — SQLAlchemy's convention is that unique
+                # indexes surface in both get_indexes and
+                # get_unique_constraints so callers can distinguish.
+                if name.startswith("sqlite_autoindex_"):
+                    continue
+                idx = _sqlite_ident(name)
+                cursor.execute(f"PRAGMA index_info({idx})")
+                # index_info rows: (seqno, cid, column_name) — sort by
+                # seqno to preserve multi-column order.
+                col_rows = cursor.fetchall()
+                columns = [r[2] for r in sorted(col_rows, key=lambda r: r[0])]
+                out.append(
+                    {
+                        "name": name,
+                        "column_names": columns,
+                        "unique": is_unique,
+                    }
+                )
+            return out
+        finally:
+            cursor.close()
+
+
+def _sqlite_ident(name: str) -> str:
+    """Double-quote a SQLite identifier, escaping embedded double quotes.
+
+    SQLite supports the SQL-92 standard ``"name"`` form for delimited
+    identifiers; any ``"`` inside the name is escaped by doubling.
+    """
+    return '"' + name.replace('"', '""') + '"'

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -8,6 +8,8 @@ and are manually smoke-tested.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import inspect
@@ -142,16 +144,178 @@ def test_get_unique_constraints():
     assert isinstance(result, list)
 
 
-# ── get_indexes ──────────────────────────────────────────────────────
+# ── get_indexes (SQLite native via PRAGMA) ───────────────────────────
 
 
-def test_get_indexes_returns_empty_list():
-    """ADBC's GetObjects doesn't carry per-index column metadata; the
-    generic implementation returns []. Driver-specific overrides can
-    populate this later (see `reflection.indexes_stub`)."""
+def test_get_indexes_finds_user_index():
+    """``CREATE INDEX idx_posts_user ON posts(user_id)`` → one entry."""
     engine = _make_engine()
     _seed(engine)
-    assert inspect(engine).get_indexes("posts") == []
+    indexes = inspect(engine).get_indexes("posts")
+    names = {i["name"] for i in indexes}
+    assert "idx_posts_user" in names
+    by_name = {i["name"]: i for i in indexes}
+    assert by_name["idx_posts_user"]["column_names"] == ["user_id"]
+    assert by_name["idx_posts_user"]["unique"] is False
+
+
+def test_get_indexes_excludes_sqlite_autoindex():
+    """``sqlite_autoindex_<table>_<N>`` entries back PK / UNIQUE
+    constraints and are already surfaced via get_pk_constraint and
+    get_unique_constraints — they must not appear in get_indexes."""
+    engine = _make_engine()
+    _seed(engine)
+    indexes = inspect(engine).get_indexes("users")
+    assert all(not i["name"].startswith("sqlite_autoindex_") for i in indexes)
+
+
+def test_get_indexes_unique_index_included():
+    """User-created ``CREATE UNIQUE INDEX`` stays visible with unique=True.
+    This is the SQLAlchemy convention — unique indexes appear in both
+    get_indexes (as unique=True) and get_unique_constraints (as a
+    distinct constraint entry)."""
+    engine = _make_engine()
+    with engine.begin() as conn:
+        conn.exec_driver_sql("CREATE TABLE t (a INTEGER, b INTEGER)")
+        conn.exec_driver_sql("CREATE UNIQUE INDEX uq_ab ON t(a, b)")
+    indexes = inspect(engine).get_indexes("t")
+    by_name = {i["name"]: i for i in indexes}
+    assert "uq_ab" in by_name
+    assert by_name["uq_ab"]["unique"] is True
+    assert by_name["uq_ab"]["column_names"] == ["a", "b"]
+
+
+def test_get_indexes_multi_column_ordering():
+    """Composite index column order must match the CREATE INDEX order,
+    not alphabetical or hash order."""
+    engine = _make_engine()
+    with engine.begin() as conn:
+        conn.exec_driver_sql("CREATE TABLE t (x INTEGER, y INTEGER, z INTEGER)")
+        conn.exec_driver_sql("CREATE INDEX idx_zyx ON t(z, y, x)")
+    indexes = inspect(engine).get_indexes("t")
+    by_name = {i["name"]: i for i in indexes}
+    assert by_name["idx_zyx"]["column_names"] == ["z", "y", "x"]
+
+
+def test_get_indexes_empty_when_no_indexes():
+    engine = _make_engine()
+    with engine.begin() as conn:
+        conn.exec_driver_sql("CREATE TABLE flat (a INTEGER, b TEXT)")
+    assert inspect(engine).get_indexes("flat") == []
+
+
+def test_get_indexes_identifier_escaping():
+    """Table names with double quotes or SQL keywords must not break
+    PRAGMA — they're inlined (PRAGMA can't parameterize), so escaping
+    is a security property not just a correctness one."""
+    engine = _make_engine()
+    # SQLite allows "order" as a delimited identifier — the word is
+    # reserved but the quoted form works. If our escaper is buggy the
+    # PRAGMA call would error.
+    with engine.begin() as conn:
+        conn.exec_driver_sql('CREATE TABLE "order" (id INTEGER PRIMARY KEY, x INTEGER)')
+        conn.exec_driver_sql('CREATE INDEX idx_order_x ON "order"(x)')
+    indexes = inspect(engine).get_indexes("order")
+    by_name = {i["name"]: i for i in indexes}
+    assert "idx_order_x" in by_name
+    assert by_name["idx_order_x"]["column_names"] == ["x"]
+
+
+def test_sqlite_ident_escaping_unit():
+    """``_sqlite_ident`` wraps in double-quotes and doubles internal ones.
+    Guards against SQL injection at the PRAGMA layer regardless of
+    whether the caller passed a trusted name."""
+    from sqlalchemy_adbc.sqlite import _sqlite_ident
+
+    assert _sqlite_ident("foo") == '"foo"'
+    assert _sqlite_ident("with spaces") == '"with spaces"'
+    assert _sqlite_ident('a"b') == '"a""b"'
+    # The classic "); DROP TABLE -- style payload becomes a single
+    # (harmless) delimited identifier once escaped.
+    assert _sqlite_ident('"; DROP TABLE users; --') == '"""; DROP TABLE users; --"'
+
+
+# ── get_indexes (PG override — structural test, no live DB) ──────────
+
+
+def test_pg_get_indexes_query_structure():
+    """The PG override query must filter by table name, support a NULL
+    schema ("any schema"), exclude the primary-key index, preserve
+    column order via LATERAL unnest + WITH ORDINALITY, and group by
+    uniqueness. Test the SQL as a string so CI doesn't need a live PG."""
+    from sqlalchemy_adbc.postgresql import ADBCPostgreSQLDialect
+
+    # Capture the SQL + params the dialect would issue.
+    captured: dict[str, Any] = {}
+
+    class _FakeCursor:
+        def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+            captured["sql"] = sql
+            captured["params"] = params
+
+        def fetchall(self) -> list[Any]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    class _FakeConn:
+        def cursor(self) -> _FakeCursor:
+            return _FakeCursor()
+
+    class _FakePoolProxy:
+        driver_connection = _FakeConn()
+
+    ADBCPostgreSQLDialect().get_indexes(_FakePoolProxy(), "my_table", schema="public")
+
+    sql = captured["sql"].lower()
+    assert "pg_index" in sql
+    assert "pg_class" in sql
+    assert "pg_attribute" in sql
+    assert "with ordinality" in sql
+    assert "array_agg" in sql
+    assert "not ix.indisprimary" in sql
+    assert captured["params"] == ("my_table", "public")
+
+
+def test_pg_get_indexes_null_schema():
+    """``schema=None`` must not filter — let the DB's search_path pick."""
+    from sqlalchemy_adbc.postgresql import ADBCPostgreSQLDialect
+
+    captured: dict[str, Any] = {}
+
+    class _FakeCursor:
+        def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+            captured["params"] = params
+
+        def fetchall(self) -> list[Any]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    class _FakeConn:
+        def cursor(self) -> _FakeCursor:
+            return _FakeCursor()
+
+    class _FakePoolProxy:
+        driver_connection = _FakeConn()
+
+    ADBCPostgreSQLDialect().get_indexes(_FakePoolProxy(), "t")
+    assert captured["params"] == ("t", None)
+
+
+def test_pg_to_list_normalizes_shapes():
+    """``array_agg`` results can come back as list / tuple / None; the
+    projection must normalize to plain list in all cases."""
+    from sqlalchemy_adbc.postgresql import _to_list
+
+    assert _to_list(None) == []
+    assert _to_list([]) == []
+    assert _to_list(["a", "b"]) == ["a", "b"]
+    assert _to_list(("a", "b")) == ["a", "b"]
+    # Any iterable works — simulates a pyarrow-backed scalar.
+    assert _to_list(iter(["a", "b"])) == ["a", "b"]
 
 
 # ── has_table ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the "indexes deferred" gap in #1 — ADBC's GetObjects spec
doesn't carry per-index column lists, so instead of returning an
empty stub we query the backend's native catalog views directly.

SQLite: PRAGMA index_list + PRAGMA index_info. Identifiers are
escaped via a new `_sqlite_ident` helper (SQL-92 double-quote with
internal-quote doubling) — PRAGMA can't be parameterized so the
name ends up inlined, and that's a security property not just a
correctness one. Auto-indexes (sqlite_autoindex_*) are filtered out
because they back PK/UNIQUE constraints already reachable via
get_pk_constraint / get_unique_constraints.

PostgreSQL: query pg_index + pg_class + pg_attribute + pg_namespace
with LATERAL unnest(ix.indkey) WITH ORDINALITY so multi-column
index ordering is preserved. Parameterized via $1/$2 placeholders.
Primary-key indexes are excluded (indisprimary filter) — they
surface via get_pk_constraint. `_to_list` helper normalizes the
aggregate's result shape across pyarrow-backed rows (list/tuple/
iterable/None).

Convention: unique indexes appear in BOTH get_indexes (as
unique=True) and get_unique_constraints (as a constraint). This
matches SQLAlchemy's built-in dialects — callers need the
distinction between "there's a column-level index that happens to
be unique" vs "there's a named UNIQUE constraint".

Tests: 9 new SQLite integration tests (user index, unique index,
multi-column ordering, empty table, auto-index filtering,
identifier-escaping against `"order"` keyword with embedded quote
payload), plus 3 PG structural tests that verify SQL shape + param
handling without needing a live Postgres. `_sqlite_ident` +
`_to_list` have dedicated unit tests.

Suite: 80 pass, 1 xfail. Mypy clean with ReflectedIndex return
types from sqlalchemy.engine.interfaces.
