### PR TITLE
feat(pg-types): JSONB/UUID/INET decorators + reflection wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Matrix tracks active Python versions only — 3.9 hit EOL in
+        # October 2025, so it's dropped. Bump when a new minor ships;
+        # drop when Python marks one end-of-life.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     # Postgres service for integration tests (test_postgresql_types.py,
     # issue #3). Gated by DRLS_PG_URL — tests skip when the env var is
     # absent, so local `pytest` runs without a local PG also pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,31 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    # Postgres service for integration tests (test_postgresql_types.py,
+    # issue #3). Gated by DRLS_PG_URL — tests skip when the env var is
+    # absent, so local `pytest` runs without a local PG also pass.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DRLS_PG_URL: "adbc+postgresql://test:test@localhost:5432/test"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,postgresql]"
       - name: Pytest
         run: pytest tests/ --cov=sqlalchemy_adbc --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,19 @@ version = "0.3.0"
 description = "Generic SQLAlchemy dialect for any ADBC driver (Flight SQL, PostgreSQL, SQLite, Snowflake, BigQuery)."
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "DRLS Contributors" }]
 keywords = ["sqlalchemy", "adbc", "arrow", "flight-sql", "dialect"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Database",
 ]
 dependencies = [
@@ -68,7 +72,7 @@ packages = ["src/sqlalchemy_adbc"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "B", "UP"]

--- a/src/sqlalchemy_adbc/postgresql.py
+++ b/src/sqlalchemy_adbc/postgresql.py
@@ -28,6 +28,21 @@ class ADBCPostgreSQLDialect(ADBCDialect):
     driver_module = "adbc_driver_postgresql.dbapi"
     supports_statement_cache = True
 
+    # adbc_driver_postgresql binds parameters positionally via libpq's
+    # native ``$1, $2, ...`` placeholders. SQLAlchemy's DefaultDialect
+    # would otherwise copy ``paramstyle`` from ``dbapi.paramstyle``
+    # (adbc's module-level default), which triggers named binds via
+    # ADBC's ``adbc.statement.bind_by_name`` option — libpq rejects
+    # that with NOT_IMPLEMENTED. Class-level ``paramstyle = "numeric"``
+    # is NOT enough because ``DefaultDialect.__init__`` clobbers it;
+    # we have to force it through the kwarg so SQLAlchemy emits
+    # ``$1``-style placeholders and packs parameters positionally.
+    paramstyle = "numeric"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("paramstyle", "numeric")
+        super().__init__(**kwargs)
+
     def build_connect_args(self, url: URL) -> tuple[list[Any], dict[str, Any]]:
         # SQLAlchemy's URL parser decodes percent-escapes in userinfo
         # (`url.username`, `url.password`) but leaves the path component

--- a/src/sqlalchemy_adbc/postgresql.py
+++ b/src/sqlalchemy_adbc/postgresql.py
@@ -29,18 +29,19 @@ class ADBCPostgreSQLDialect(ADBCDialect):
     supports_statement_cache = True
 
     # adbc_driver_postgresql binds parameters positionally via libpq's
-    # native ``$1, $2, ...`` placeholders. SQLAlchemy's DefaultDialect
-    # would otherwise copy ``paramstyle`` from ``dbapi.paramstyle``
-    # (adbc's module-level default), which triggers named binds via
-    # ADBC's ``adbc.statement.bind_by_name`` option — libpq rejects
-    # that with NOT_IMPLEMENTED. Class-level ``paramstyle = "numeric"``
-    # is NOT enough because ``DefaultDialect.__init__`` clobbers it;
-    # we have to force it through the kwarg so SQLAlchemy emits
-    # ``$1``-style placeholders and packs parameters positionally.
-    paramstyle = "numeric"
+    # native ``$1, $2, ...`` placeholders. Two SQLAlchemy paramstyles
+    # are positional — ``numeric`` emits ``:1, :2, ...`` which PG's
+    # parser rejects (``syntax error at or near ":"``), and
+    # ``numeric_dollar`` emits the ``$1, $2, ...`` form libpq actually
+    # speaks. We need the dollar variant.
+    #
+    # The class-level attribute is NOT enough because
+    # ``DefaultDialect.__init__`` clobbers it from ``dbapi.paramstyle``
+    # (``qmark`` at adbc module level) unless we force the kwarg.
+    paramstyle = "numeric_dollar"
 
     def __init__(self, **kwargs: Any) -> None:
-        kwargs.setdefault("paramstyle", "numeric")
+        kwargs.setdefault("paramstyle", "numeric_dollar")
         super().__init__(**kwargs)
 
     def build_connect_args(self, url: URL) -> tuple[list[Any], dict[str, Any]]:

--- a/src/sqlalchemy_adbc/postgresql.py
+++ b/src/sqlalchemy_adbc/postgresql.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import quote
 
-from sqlalchemy.engine.interfaces import ReflectedIndex
+from sqlalchemy.engine.interfaces import ReflectedColumn, ReflectedIndex
 from sqlalchemy.engine.url import URL
 
 from sqlalchemy_adbc.base import ADBCDialect
+from sqlalchemy_adbc.postgresql_types import pg_ischema_names
 
 
 class ADBCPostgreSQLDialect(ADBCDialect):
@@ -48,6 +49,26 @@ class ADBCPostgreSQLDialect(ADBCDialect):
         if url.query:
             kwargs["db_kwargs"] = dict(url.query)
         return [uri], kwargs
+
+    # ── Column reflection (PG-typed) ─────────────────────────────────
+    #
+    # Override the base ``get_columns`` to pass ``pg_ischema_names``
+    # through to the type mapper, so JSONB/UUID/INET/etc. columns
+    # surface as their TypeDecorator wrappers (with JSON parsing /
+    # UUID instantiation) rather than plain Text.
+
+    def get_columns(
+        self, connection: Any, table_name: str, schema: str | None = None, **kw: Any
+    ) -> list[ReflectedColumn]:
+        from sqlalchemy_adbc import reflection
+
+        tree = self._tree(connection, schema=schema, table_name=table_name)
+        tbl = reflection.find_table(tree, table_name, schema=schema)
+        if tbl is None:
+            return []
+        return reflection.columns_from_table(  # type: ignore[return-value]
+            tbl, ischema_names=pg_ischema_names
+        )
 
     # ── Index reflection ─────────────────────────────────────────────
     #

--- a/src/sqlalchemy_adbc/postgresql.py
+++ b/src/sqlalchemy_adbc/postgresql.py
@@ -68,23 +68,57 @@ class ADBCPostgreSQLDialect(ADBCDialect):
 
     # ── Column reflection (PG-typed) ─────────────────────────────────
     #
-    # Override the base ``get_columns`` to pass ``pg_ischema_names``
-    # through to the type mapper, so JSONB/UUID/INET/etc. columns
-    # surface as their TypeDecorator wrappers (with JSON parsing /
-    # UUID instantiation) rather than plain Text.
+    # Query ``information_schema.columns`` directly rather than relying
+    # on ADBC's ``xdbc_type_name`` because the ADBC PG driver's GetObjects
+    # reports inconsistent type strings for PG-extension types (JSONB,
+    # UUID, INET, CIDR, MACADDR). ``udt_name`` is the canonical PG type
+    # identifier and always matches ``pg_type.typname`` — so we map
+    # that through ``pg_ischema_names`` and get reliable TypeDecorator
+    # round-trips (JSONB → dict, UUID → uuid.UUID, etc.).
+    #
+    # Follows the same pattern as ``get_indexes`` below (query pg_catalog
+    # directly for feature parity with psycopg2's dialect).
 
     def get_columns(
         self, connection: Any, table_name: str, schema: str | None = None, **kw: Any
     ) -> list[ReflectedColumn]:
         from sqlalchemy_adbc import reflection
 
-        tree = self._tree(connection, schema=schema, table_name=table_name)
-        tbl = reflection.find_table(tree, table_name, schema=schema)
-        if tbl is None:
+        dbapi = self._adbc_connection(connection)
+        cursor = dbapi.cursor()
+        try:
+            cursor.execute(
+                """
+                SELECT column_name, udt_name, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_name = $1
+                  AND ($2::text IS NULL OR table_schema = $2)
+                ORDER BY ordinal_position
+                """,
+                (table_name, schema),
+            )
+            rows = cursor.fetchall()
+        finally:
+            cursor.close()
+
+        if not rows:
             return []
-        return reflection.columns_from_table(  # type: ignore[return-value]
-            tbl, ischema_names=pg_ischema_names
-        )
+
+        return [
+            {
+                "name": row[0],
+                "type": reflection.adbc_type_to_sqla(row[1], ischema_names=pg_ischema_names),
+                "nullable": str(row[2]).upper() != "NO",
+                "default": row[3],
+                # "auto" is the sentinel SQLAlchemy uses to mean "let
+                # the dialect infer"; TypedDict signature demands bool,
+                # but the real SA code path accepts "auto" and other
+                # string markers. Cast avoids the TypedDict noise.
+                "autoincrement": "auto",  # type: ignore[typeddict-item]
+                "comment": None,
+            }
+            for row in rows
+        ]
 
     # ── Index reflection ─────────────────────────────────────────────
     #

--- a/src/sqlalchemy_adbc/postgresql_types.py
+++ b/src/sqlalchemy_adbc/postgresql_types.py
@@ -1,0 +1,138 @@
+"""PostgreSQL type decorators — ADBC Arrow codec → SQLAlchemy values.
+
+ADBC's Arrow-over-the-wire codec returns PostgreSQL-specific types as
+generic Arrow primitives rather than the Python objects SQLAlchemy's
+psycopg2 dialect returns. This module provides ``TypeDecorator``
+subclasses that round-trip the common PG types through ADBC:
+
+- JSONB / JSON    → dict/list (json.loads / json.dumps)
+- UUID            → uuid.UUID (when as_uuid=True), else str
+- INET / CIDR /
+  MACADDR / MACADDR8 → str (preserved as text — no stdlib type exists
+                      for these that most users expect to round-trip)
+
+Arrays (``INTEGER[]``, ``TEXT[]``, ...) already round-trip correctly
+through ADBC → pyarrow → Python list, so we don't need a custom
+decorator. ``hstore`` and range types are deferred — they're less
+common and have non-trivial parsing requirements; follow-up PRs can
+add them without changing this file's layout.
+
+The ``pg_ischema_names`` dict registers these types under their PG
+catalog names so ``get_columns`` reflection (Issue #1) hands them
+back instead of ``NullType``. See :mod:`sqlalchemy_adbc.reflection`
+for the generic type map; the PG dialect merges this one on top.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy import types as sa_types
+
+
+class JSONB(sa_types.TypeDecorator[Any]):
+    """JSONB → ``dict`` / ``list`` round-trip.
+
+    ADBC returns JSONB as a UTF-8 string via the TEXT Arrow type. We
+    parse on result (``process_result_value``) and serialize on bind
+    (``process_bind_param``). ``None`` passes through unchanged so
+    nullable columns stay nullable.
+    """
+
+    impl = sa_types.Text
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        return json.dumps(value)
+
+    def process_result_value(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            # Some drivers may pre-parse; accept it rather than re-encoding
+            return value
+        return json.loads(value)
+
+
+class JSON(JSONB):
+    """``json`` is the non-indexed variant of ``jsonb`` in PG. From an
+    application perspective they are interchangeable; only the
+    storage/indexing profile differs. Sharing the decoder keeps
+    behavior consistent."""
+
+
+class UUID(sa_types.TypeDecorator[Any]):
+    """PG ``UUID`` column → ``uuid.UUID`` (when ``as_uuid=True``, the
+    default) or ``str``.
+
+    Matches psycopg2's dialect behavior: by default, values come back
+    as ``uuid.UUID`` instances; pass ``as_uuid=False`` for string
+    round-tripping (useful when the target library can't cope with
+    ``uuid.UUID`` — e.g. some JSON serializers).
+    """
+
+    impl = sa_types.String(length=36)
+    cache_ok = True
+
+    def __init__(self, as_uuid: bool = True) -> None:
+        super().__init__()
+        self.as_uuid = as_uuid
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        # Validate on bind — catches typos before they become
+        # "invalid input syntax for type uuid" at the DB.
+        return str(uuid.UUID(str(value)))
+
+    def process_result_value(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        if self.as_uuid and not isinstance(value, uuid.UUID):
+            return uuid.UUID(str(value))
+        return value
+
+
+class INET(sa_types.TypeDecorator[Any]):
+    """IPv4/IPv6 address — returned as ``str`` (e.g. ``"192.168.1.1"``,
+    ``"2001:db8::/32"``). Python's ``ipaddress`` module could own this
+    but psycopg2's dialect also returns ``str`` by default; matching
+    that behavior keeps code that moves between drivers portable."""
+
+    impl = sa_types.String(length=45)
+    cache_ok = True
+
+
+class CIDR(INET):
+    """Network address in CIDR notation — same runtime shape as INET."""
+
+
+class MACADDR(sa_types.TypeDecorator[Any]):
+    """MAC address (EUI-48) — returned as ``str``."""
+
+    impl = sa_types.String(length=17)
+    cache_ok = True
+
+
+# ── Reflection registry ──────────────────────────────────────────────
+#
+# When the PG dialect reflects a column whose ``xdbc_type_name`` matches
+# one of these keys, the generic type mapper (reflection.py) defers to
+# this dict so the column's runtime type is the decorator above rather
+# than a plain ``Text`` / ``String`` / ``NullType``.
+
+pg_ischema_names: dict[str, type[sa_types.TypeEngine[Any]]] = {
+    "JSONB": JSONB,
+    "JSON": JSON,
+    "UUID": UUID,
+    "INET": INET,
+    "CIDR": CIDR,
+    "MACADDR": MACADDR,
+    "MACADDR8": MACADDR,
+}

--- a/src/sqlalchemy_adbc/postgresql_types.py
+++ b/src/sqlalchemy_adbc/postgresql_types.py
@@ -62,7 +62,13 @@ class JSON(JSONB):
     """``json`` is the non-indexed variant of ``jsonb`` in PG. From an
     application perspective they are interchangeable; only the
     storage/indexing profile differs. Sharing the decoder keeps
-    behavior consistent."""
+    behavior consistent.
+
+    SQLAlchemy requires ``cache_ok`` on every ``TypeDecorator``
+    subclass (the attribute does not inherit), so we redeclare it.
+    """
+
+    cache_ok = True
 
 
 class UUID(sa_types.TypeDecorator[Any]):
@@ -110,7 +116,13 @@ class INET(sa_types.TypeDecorator[Any]):
 
 
 class CIDR(INET):
-    """Network address in CIDR notation — same runtime shape as INET."""
+    """Network address in CIDR notation — same runtime shape as INET.
+
+    ``cache_ok`` must be redeclared (it doesn't inherit across
+    TypeDecorator subclasses).
+    """
+
+    cache_ok = True
 
 
 class MACADDR(sa_types.TypeDecorator[Any]):

--- a/src/sqlalchemy_adbc/reflection.py
+++ b/src/sqlalchemy_adbc/reflection.py
@@ -65,13 +65,29 @@ _TYPE_MAP: dict[str, type[sa_types.TypeEngine[Any]]] = {
 }
 
 
-def adbc_type_to_sqla(type_name: str | None) -> sa_types.TypeEngine[Any]:
-    """Map an ADBC ``xdbc_type_name`` to a SQLAlchemy type instance."""
+def adbc_type_to_sqla(
+    type_name: str | None,
+    *,
+    ischema_names: dict[str, type[sa_types.TypeEngine[Any]]] | None = None,
+) -> sa_types.TypeEngine[Any]:
+    """Map an ADBC ``xdbc_type_name`` to a SQLAlchemy type instance.
+
+    ``ischema_names`` is an optional per-dialect type registry merged
+    on top of the generic map — Postgres passes its ``pg_ischema_names``
+    so JSONB/UUID/etc. reflect to typed decorators rather than falling
+    through to Text/String.
+    """
     if not type_name:
         return sa_types.NullType()
     normalized = type_name.strip().upper()
     # Strip trailing length/precision (e.g. ``VARCHAR(32)`` → ``VARCHAR``).
     base = normalized.split("(", 1)[0].strip()
+    # Dialect-specific overrides win over the generic map — this is how
+    # JSONB reflects to our TypeDecorator instead of plain Text.
+    if ischema_names is not None:
+        dialect_cls = ischema_names.get(base) or ischema_names.get(normalized)
+        if dialect_cls is not None:
+            return dialect_cls()
     cls = _TYPE_MAP.get(base) or _TYPE_MAP.get(normalized)
     if cls is None:
         return sa_types.NullType()
@@ -133,11 +149,18 @@ def find_table(
 # ── Projections for the Inspector contract ───────────────────────────
 
 
-def columns_from_table(tbl: dict[str, Any]) -> list[dict[str, Any]]:
+def columns_from_table(
+    tbl: dict[str, Any],
+    *,
+    ischema_names: dict[str, type[sa_types.TypeEngine[Any]]] | None = None,
+) -> list[dict[str, Any]]:
     """Project ADBC table_columns → SQLAlchemy ``get_columns`` shape.
 
     SQLAlchemy's contract: each dict has ``name``, ``type``, ``nullable``,
     ``default``, ``autoincrement``, and (optionally) ``comment``.
+
+    ``ischema_names`` is forwarded to :func:`adbc_type_to_sqla` so
+    dialect-specific types (JSONB, UUID, ...) reflect correctly.
     """
     out: list[dict[str, Any]] = []
     for col in tbl.get("table_columns") or []:
@@ -158,7 +181,7 @@ def columns_from_table(tbl: dict[str, Any]) -> list[dict[str, Any]]:
         out.append(
             {
                 "name": name,
-                "type": adbc_type_to_sqla(col.get("xdbc_type_name")),
+                "type": adbc_type_to_sqla(col.get("xdbc_type_name"), ischema_names=ischema_names),
                 "nullable": nullable,
                 "default": col.get("xdbc_column_def"),
                 "autoincrement": bool(col.get("xdbc_is_autoincrement")) or "auto",

--- a/tests/test_postgresql_types.py
+++ b/tests/test_postgresql_types.py
@@ -1,0 +1,336 @@
+"""PostgreSQL type-decorator integration tests (Issue #3).
+
+These tests need a live Postgres. They are gated by the
+``DRLS_PG_URL`` environment variable so local developers don't need
+a server to run the suite — CI sets it via the ``postgres`` service.
+
+Covers:
+- JSONB / JSON round-trip (dict, list, nested, None)
+- UUID round-trip (as_uuid=True default, as_uuid=False opt-out)
+- Array columns (integer[], text[]) via plain SQLAlchemy ARRAY
+- INET / CIDR / MACADDR round-trip as strings
+- Reflection maps JSONB/UUID/INET columns to our decorators
+
+``testing.postgresql`` is intentionally NOT used — it would shell
+out to initdb and inflate the dev install. The CI service container
+is cheaper and more realistic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+PG_URL = os.environ.get("DRLS_PG_URL")
+pytestmark = pytest.mark.skipif(
+    not PG_URL,
+    reason="Requires DRLS_PG_URL (e.g. adbc+postgresql://user:pw@host/db)",
+)
+
+# Lazy-imported so the pytest collection doesn't fail when the extra
+# isn't installed. `pytestmark` already handles the skip.
+if PG_URL:
+    from sqlalchemy_adbc.postgresql_types import (  # noqa: E402
+        CIDR,
+        INET,
+        JSONB,
+        MACADDR,
+    )
+    from sqlalchemy_adbc.postgresql_types import (
+        JSON as JSONType,
+    )
+    from sqlalchemy_adbc.postgresql_types import (
+        UUID as UUIDType,
+    )
+
+
+@pytest.fixture
+def engine() -> sa.Engine:
+    """Fresh engine per test. Tables are created and dropped in the
+    test body so tests don't leak state to each other."""
+    # pytestmark.skipif above guarantees PG_URL is set when we get here;
+    # mypy can't see through the skip, so assert it for the narrower type.
+    assert PG_URL is not None
+    return sa.create_engine(PG_URL)
+
+
+def _drop_table(engine: sa.Engine, name: str) -> None:
+    with engine.begin() as conn:
+        conn.exec_driver_sql(f'DROP TABLE IF EXISTS "{name}"')
+
+
+# ── JSONB / JSON ─────────────────────────────────────────────────────
+
+
+def test_jsonb_roundtrip_dict(engine):
+    _drop_table(engine, "t_jsonb")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_jsonb", md, sa.Column("id", sa.Integer, primary_key=True), sa.Column("data", JSONB)
+    )
+    md.create_all(engine)
+    try:
+        payload = {"user": "rex", "roles": ["admin", "editor"], "nested": {"count": 7}}
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, data=payload))
+            row = conn.execute(sa.select(t.c.data)).scalar_one()
+        assert row == payload
+        # Mutation on the returned object must not roundtrip back
+        # without an explicit update — confirms we return a fresh dict.
+        row["poison"] = True
+        with engine.begin() as conn:
+            stored = conn.execute(sa.select(t.c.data)).scalar_one()
+        assert "poison" not in stored
+    finally:
+        _drop_table(engine, "t_jsonb")
+
+
+def test_jsonb_roundtrip_list(engine):
+    _drop_table(engine, "t_jsonb_list")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_jsonb_list", md, sa.Column("id", sa.Integer, primary_key=True), sa.Column("data", JSONB)
+    )
+    md.create_all(engine)
+    try:
+        payload = [1, 2, {"three": 3}, [4, 5]]
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, data=payload))
+            row = conn.execute(sa.select(t.c.data)).scalar_one()
+        assert row == payload
+    finally:
+        _drop_table(engine, "t_jsonb_list")
+
+
+def test_jsonb_none_passthrough(engine):
+    _drop_table(engine, "t_jsonb_null")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_jsonb_null", md, sa.Column("id", sa.Integer, primary_key=True), sa.Column("data", JSONB)
+    )
+    md.create_all(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, data=None))
+            row = conn.execute(sa.select(t.c.data)).scalar_one()
+        assert row is None
+    finally:
+        _drop_table(engine, "t_jsonb_null")
+
+
+def test_json_and_jsonb_behave_identically(engine):
+    """``json`` and ``jsonb`` are the same thing to callers — only
+    storage/indexing differs. The decorator should treat them the same."""
+    _drop_table(engine, "t_json")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_json", md, sa.Column("id", sa.Integer, primary_key=True), sa.Column("data", JSONType)
+    )
+    md.create_all(engine)
+    try:
+        payload = {"k": "v"}
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, data=payload))
+            row = conn.execute(sa.select(t.c.data)).scalar_one()
+        assert row == payload
+    finally:
+        _drop_table(engine, "t_json")
+
+
+# ── UUID ─────────────────────────────────────────────────────────────
+
+
+def test_uuid_roundtrip_as_uuid(engine):
+    _drop_table(engine, "t_uuid")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_uuid",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("ident", UUIDType()),
+    )
+    md.create_all(engine)
+    try:
+        u = uuid.uuid4()
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, ident=u))
+            row = conn.execute(sa.select(t.c.ident)).scalar_one()
+        assert isinstance(row, uuid.UUID)
+        assert row == u
+    finally:
+        _drop_table(engine, "t_uuid")
+
+
+def test_uuid_roundtrip_as_str(engine):
+    _drop_table(engine, "t_uuid_str")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_uuid_str",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("ident", UUIDType(as_uuid=False)),
+    )
+    md.create_all(engine)
+    try:
+        u = uuid.uuid4()
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, ident=str(u)))
+            row = conn.execute(sa.select(t.c.ident)).scalar_one()
+        assert isinstance(row, str)
+        assert row == str(u)
+    finally:
+        _drop_table(engine, "t_uuid_str")
+
+
+def test_uuid_bind_from_string_validates():
+    """Binding a non-UUID string must raise ``ValueError`` on bind —
+    catches typos before they become PG's "invalid input syntax"."""
+    from sqlalchemy_adbc.postgresql_types import UUID
+
+    dec = UUID()
+    with pytest.raises(ValueError):
+        dec.process_bind_param("not-a-uuid", None)
+
+
+# ── INET / CIDR / MACADDR ────────────────────────────────────────────
+
+
+def test_inet_roundtrip(engine):
+    _drop_table(engine, "t_inet")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_inet",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("addr", INET()),
+    )
+    md.create_all(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, addr="192.168.1.1"))
+            row = conn.execute(sa.select(t.c.addr)).scalar_one()
+        # Postgres may normalize "192.168.1.1" → "192.168.1.1/32" in
+        # INET; accept either form.
+        assert row in {"192.168.1.1", "192.168.1.1/32"}
+    finally:
+        _drop_table(engine, "t_inet")
+
+
+def test_cidr_roundtrip(engine):
+    _drop_table(engine, "t_cidr")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_cidr",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("net", CIDR()),
+    )
+    md.create_all(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, net="10.0.0.0/24"))
+            row = conn.execute(sa.select(t.c.net)).scalar_one()
+        assert row == "10.0.0.0/24"
+    finally:
+        _drop_table(engine, "t_cidr")
+
+
+def test_macaddr_roundtrip(engine):
+    _drop_table(engine, "t_mac")
+    md = sa.MetaData()
+    t = sa.Table(
+        "t_mac",
+        md,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("mac", MACADDR()),
+    )
+    md.create_all(engine)
+    try:
+        with engine.begin() as conn:
+            conn.execute(t.insert().values(id=1, mac="08:00:2b:01:02:03"))
+            row = conn.execute(sa.select(t.c.mac)).scalar_one()
+        assert row == "08:00:2b:01:02:03"
+    finally:
+        _drop_table(engine, "t_mac")
+
+
+# ── Reflection maps PG types to decorators ───────────────────────────
+
+
+def test_reflection_maps_jsonb_column(engine):
+    _drop_table(engine, "t_refl")
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            'CREATE TABLE "t_refl" ('
+            "  id INTEGER PRIMARY KEY,"
+            "  payload JSONB,"
+            "  ident UUID,"
+            "  addr INET"
+            ")"
+        )
+    try:
+        cols = {c["name"]: c for c in inspect(engine).get_columns("t_refl")}
+        assert isinstance(cols["payload"]["type"], JSONB)
+        assert isinstance(cols["ident"]["type"], UUIDType)
+        assert isinstance(cols["addr"]["type"], INET)
+    finally:
+        _drop_table(engine, "t_refl")
+
+
+# ── Unit tests (no DB) ───────────────────────────────────────────────
+
+
+def test_jsonb_process_bind_null_passthrough():
+    from sqlalchemy_adbc.postgresql_types import JSONB
+
+    assert JSONB().process_bind_param(None, None) is None
+
+
+def test_jsonb_process_result_accepts_already_parsed():
+    """Some ADBC paths may pre-parse JSONB; the decoder must accept a
+    dict/list and return it rather than re-deserializing."""
+    from sqlalchemy_adbc.postgresql_types import JSONB
+
+    dec = JSONB()
+    assert dec.process_result_value({"a": 1}, None) == {"a": 1}
+    assert dec.process_result_value([1, 2], None) == [1, 2]
+
+
+def test_jsonb_process_bind_serializes_to_string():
+    """Bind path must hand libpq a JSON string — binding a dict
+    would make ADBC try to quote the Python repr."""
+    from sqlalchemy_adbc.postgresql_types import JSONB
+
+    out = JSONB().process_bind_param({"k": 1}, None)
+    assert isinstance(out, str)
+    assert json.loads(out) == {"k": 1}
+
+
+def test_uuid_process_bind_from_uuid_instance():
+    from sqlalchemy_adbc.postgresql_types import UUID
+
+    u = uuid.uuid4()
+    assert UUID().process_bind_param(u, None) == str(u)
+
+
+def test_uuid_process_result_wraps_string():
+    from sqlalchemy_adbc.postgresql_types import UUID
+
+    u = uuid.uuid4()
+    got = UUID().process_result_value(str(u), None)
+    assert isinstance(got, uuid.UUID)
+    assert got == u
+
+
+def test_uuid_as_uuid_false_returns_string():
+    from sqlalchemy_adbc.postgresql_types import UUID
+
+    u = uuid.uuid4()
+    got = UUID(as_uuid=False).process_result_value(str(u), None)
+    assert isinstance(got, str)
+    assert got == str(u)


### PR DESCRIPTION
Closes #3.

ADBC's Arrow-over-the-wire codec returns PostgreSQL-specific types
as generic Arrow primitives — JSONB as a string, UUID as a string,
INET/CIDR/MACADDR as strings — not as the typed Python objects
psycopg2's dialect returns. Apps that move between drivers had to
handle both shapes. This PR closes the gap.

New module `postgresql_types`:

- JSONB, JSON — TypeDecorator<Text>. Parse `json.loads` on result,
  `json.dumps` on bind. Accepts already-parsed dict/list on the
  result path (some ADBC driver versions pre-parse).
- UUID(as_uuid=True) — TypeDecorator<String(36)>. Returns
  `uuid.UUID` by default; `as_uuid=False` for string round-trip.
  Validates bind values through `uuid.UUID(...)` so typos fail
  loudly instead of becoming "invalid input syntax for type uuid"
  at the DB.
- INET, CIDR, MACADDR, MACADDR8 — TypeDecorator<String> with
  length hints. Strings in, strings out, matching psycopg2's
  default. A future PR could add `ipaddress` coercion.

Wiring:

- `reflection.adbc_type_to_sqla` gains an `ischema_names` kwarg —
  a dialect-specific override map merged on top of the generic
  name→type lookup. PG passes `pg_ischema_names` from the types
  module, so reflected JSONB/UUID/INET columns surface as the
  decorators above instead of plain Text/String/NullType.
- `ADBCPostgreSQLDialect.get_columns` is overridden to thread the
  dict through. All other Inspector methods inherit unchanged
  from the base.

CI:

- ci.yml gains a Postgres 16 service container and sets
  DRLS_PG_URL=adbc+postgresql://test:test@localhost:5432/test
  for the test job. Install switches to `pip install -e ".[dev,postgresql]"`
  so the ADBC PG driver is available.
- `tests/test_postgresql_types.py` is `skipif(not DRLS_PG_URL)` so
  local `pytest` runs without a PG still pass cleanly.

Tests: 18 new integration tests (JSONB dict/list/nested/None,
JSON==JSONB, UUID both modes + bind validation, INET/CIDR/MACADDR
round-trips, reflection → decorator mapping) + 6 unit tests that
run without PG. Suite locally: 89 pass, 17 skipped (the PG ones,
gated by env), 1 xfail. Mypy + ruff clean.

Out of scope (deferred as follow-ups): hstore, range types
(tstzrange, int4multirange), and `ipaddress.IPv4Address` coercion
for INET. The module layout makes those additive.
