### PR TITLE
chore(release): 0.3.0 tooling — CHANGELOG, README beta, GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,3 +87,57 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    # Creates a GitHub Release for every tag push, using the matching
+    # CHANGELOG.md section as the release body. Runs AFTER the PyPI
+    # publish succeeds so we don't advertise a version that failed
+    # to upload. No binary assets attached — PyPI is the distribution
+    # channel; duplicating wheels here invites drift.
+    name: Create GitHub Release
+    needs: publish-pypi
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          # Grab the section under `## [X.Y.Z]` up to the next `## `
+          # heading (or EOF). `awk` keeps this portable across bash
+          # versions without depending on gh's CHANGELOG conventions.
+          NOTES=$(awk -v ver="$TAG" '
+            /^## \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") { found = 1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No CHANGELOG entry found for version $TAG"
+            NOTES="Release v$TAG. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          fi
+          # Append PyPI link so the Release page directs installers
+          # back to the canonical distribution.
+          NOTES="$NOTES
+
+          ---
+
+          📦 **Install:** \`pip install sqlalchemy-adbc==$TAG\` —
+          [view on PyPI](https://pypi.org/project/sqlalchemy-adbc/$TAG/)"
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          gh release create "v$TAG" \
+            --title "v$TAG" \
+            --notes "${{ steps.notes.outputs.notes }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,118 @@
+# Changelog
+
+All notable changes to `sqlalchemy-adbc` are documented here. Format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### In flight
+
+- **PG-specific type decorators** (JSONB, UUID, INET, CIDR, MACADDR)
+  on PR [#8](https://github.com/drls-io/sqlalchemy-adbc/pull/8),
+  closes [#3](https://github.com/drls-io/sqlalchemy-adbc/issues/3).
+  Blocked on a `paramstyle` fix — the default `qmark` binds don't
+  work against `adbc_driver_postgresql` (which needs `numeric`
+  `$1`-style).
+
+## [0.3.0] — 2026-04-21
+
+Largest release so far: table reflection, Alembic autogenerate, and
+a breaking fix to SQLAlchemy dialect naming conventions. Not backwards-
+compatible for callers that read `engine.dialect.name`.
+
+### Added
+
+- **Table reflection via `adbc_get_objects`** — the full SQLAlchemy
+  Inspector contract now works for any ADBC driver that implements
+  the GetObjects metadata call. Covers `get_columns`,
+  `get_pk_constraint`, `get_foreign_keys`, `get_unique_constraints`,
+  `get_table_names`, `get_view_names`, `get_schema_names`, and
+  `has_table`. `MetaData.reflect(bind=engine)` works end-to-end.
+  ([#5](https://github.com/drls-io/sqlalchemy-adbc/pull/5),
+  closes [#1](https://github.com/drls-io/sqlalchemy-adbc/issues/1))
+- **Native `get_indexes` for SQLite and PostgreSQL** — ADBC's
+  GetObjects spec doesn't carry per-index column lists, so we
+  query the backend's native catalog (PRAGMA `index_list` /
+  `index_info` for SQLite; `pg_index` / `pg_class` / `pg_attribute`
+  with `LATERAL unnest WITH ORDINALITY` for PG). Identifiers are
+  properly escaped — PRAGMA can't be parameterized.
+  ([#6](https://github.com/drls-io/sqlalchemy-adbc/pull/6))
+- **Alembic autogenerate support** — fallout from the dialect-name
+  fix below. Alembic's DDL impl registry now finds the correct
+  per-backend impl (`SQLiteImpl`, `PostgresqlImpl`) for free.
+  Covers create/drop table, add/drop column, and roundtrip
+  idempotency (apply autogenerate output → re-run → no-op).
+  ([#7](https://github.com/drls-io/sqlalchemy-adbc/pull/7),
+  closes [#2](https://github.com/drls-io/sqlalchemy-adbc/issues/2))
+
+### Changed
+
+- **BREAKING — dialect `name` and `driver` attributes flipped** to
+  match SQLAlchemy's convention: `name` is the backend identity
+  (`sqlite`, `postgresql`, `flightsql`, `snowflake`, `bigquery`),
+  `driver` is the wire path (`adbc`). Previously every dialect
+  reported `name="adbc"`, which caused Alembic's DDL-impl lookup
+  to `KeyError`. URL forms (`adbc+sqlite://`, etc.) are unchanged.
+  Callers inspecting `engine.dialect.name` must update expectations.
+
+### Fixed
+
+- `get_columns` now honors SQLAlchemy's `ReflectedColumn` shape
+  ([#5](https://github.com/drls-io/sqlalchemy-adbc/pull/5))
+- Mypy is gated in CI with proper `sqlalchemy.engine.interfaces`
+  return types
+
+## [0.2.0] — 2026-04-19
+
+Security + correctness release. Not backwards-compatible for
+Flight SQL users relying on the plaintext-by-default behavior.
+
+### Changed
+
+- **BREAKING — Flight SQL TLS is now default-on** (`tls=true`).
+  Send a bearer token over plaintext gRPC was an unmissable
+  credential-leak shape. Local/dev users on plaintext listeners
+  must now opt out with `?tls=false`. Default port auto-picks
+  443 for TLS, 50051 for plaintext (Arrow Flight convention).
+
+### Fixed
+
+- **URL → DSN special-character escaping** for PostgreSQL and
+  Snowflake. A password containing `@`, `:`, `/`, `#`, `%` was
+  previously concatenated into the DSN unquoted and would silently
+  re-route libpq to the wrong host. Username/password now routed
+  through `urllib.parse.quote`; database path stays as-is since
+  SQLAlchemy's URL parser leaves it percent-encoded.
+- mypy errors in the Flight SQL dialect around `URL.query`
+  tuple vs str handling. A `_scalar()` helper normalizes repeated
+  keys to their last value (HTTP/shell convention).
+- Formatting drift on three files.
+
+### Added
+
+- CI gates `mypy src tests` alongside the existing ruff check.
+- Extensive URL-parse test coverage: 13 PG, 9 Snowflake, 5 BigQuery
+  tests covering special-char escaping, no-credentials paths, and
+  edge cases. Total suite: 51 (up from 16).
+- Documentation of known gaps in the README (table reflection,
+  Alembic autogenerate, PG-specific types) with links to tracking
+  issues.
+
+## [0.1.0] — 2026-04-18
+
+Initial public release.
+
+### Added
+
+- Generic `ADBCDialect` base class with per-driver subclasses for
+  Flight SQL, SQLite, PostgreSQL, Snowflake, and BigQuery
+- URL → `db_kwargs` translation per driver
+- Entry-point registration under `sqlalchemy.dialects` so any
+  `adbc+<driver>://` URL resolves automatically
+- PyPI trusted publishing via OIDC
+
+[Unreleased]: https://github.com/drls-io/sqlalchemy-adbc/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/drls-io/sqlalchemy-adbc/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/drls-io/sqlalchemy-adbc/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/drls-io/sqlalchemy-adbc/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -78,33 +78,44 @@ df = pd.read_sql("SELECT 1 AS n", engine)
 
 ## Status
 
-Alpha — the core dialect machinery works for simple `SELECT` / `INSERT` /
-`CREATE TABLE` use. More advanced SQLAlchemy features are still to come;
-the known gaps are called out below so you don't waste time debugging a
-missing feature:
+**Beta.** Core dialect + reflection + Alembic autogenerate work on
+the ADBC drivers we exercise in CI (SQLite end-to-end, PostgreSQL
+via service container). Not 1.0 yet — we want a few months of
+real-world use and at least one release without breaking changes
+before committing to a stable API.
 
-- **Table reflection** (`MetaData.reflect()`): not implemented
-  ([#1](https://github.com/drls-io/sqlalchemy-adbc/issues/1)). The ADBC
-  driver exposes table/column metadata via the Arrow-based `GetObjects`
-  call, but this library doesn't yet wire that into SQLAlchemy's
-  `Inspector` contract. PRs welcome.
-- **Alembic autogenerate**
-  ([#2](https://github.com/drls-io/sqlalchemy-adbc/issues/2)): follows
-  from reflection — won't work until #1 lands. `alembic upgrade`
-  against already-written migrations is fine (it's pure SQL).
-- **PostgreSQL-specific types** (JSONB, ARRAY, UUID, TSTZMULTIRANGE,
-  …) ([#3](https://github.com/drls-io/sqlalchemy-adbc/issues/3)):
-  ADBC's Arrow-over-the-wire codec returns these as strings / lists of
-  primitives, not as SQLAlchemy's typed objects. If you need ORM-level
-  round-tripping of PG-specific types, use `psycopg2` until we add a
-  type compiler.
-- **Query parameterization**: uses ADBC's native `$1`-style placeholders
-  for PostgreSQL and `?` for SQLite. Flight SQL and Snowflake delegate
-  to the driver's default.
+Full history in [CHANGELOG.md](CHANGELOG.md). Download tags on
+[GitHub Releases](https://github.com/drls-io/sqlalchemy-adbc/releases);
+published wheels on [PyPI](https://pypi.org/project/sqlalchemy-adbc/).
 
-PRs welcome.
+### What works
 
-Tests: 52+ passing against ADBC SQLite + URL/DSN translators on Python 3.9–3.13.
+- `SELECT` / `INSERT` / `CREATE TABLE` / `DROP TABLE` / `ALTER TABLE`
+  for every advertised driver
+- `MetaData.reflect(bind=engine)` — full Inspector contract backed
+  by ADBC `GetObjects`, including columns, PK, FK, unique
+  constraints, indexes (native PRAGMA / `pg_catalog` queries on
+  SQLite and PG)
+- Alembic `autogenerate` — end-to-end, reusing SQLAlchemy's native
+  backend DDL impls via standard dialect-name lookup
+- URL forms for Flight SQL, PostgreSQL, SQLite, Snowflake, BigQuery
+  with correct special-character escaping in passwords
+
+### Known limitations
+
+- **PostgreSQL-specific types** (JSONB, UUID, INET, ranges) — in
+  flight ([#3](https://github.com/drls-io/sqlalchemy-adbc/issues/3),
+  [#8](https://github.com/drls-io/sqlalchemy-adbc/pull/8)); current
+  release returns them as raw strings
+- **Drivers exercised in CI** — SQLite fully, PostgreSQL
+  integration-tested. Snowflake/BigQuery/Flight SQL inherit the
+  shared reflection path but have no per-driver CI
+- **ADBC SQLite NOT NULL reporting** — upstream driver always
+  reports nullable=True; reflection faithfully reflects that
+  (tracked, auto-reactivating xfail)
+
+Tests: 89+ passing on Python 3.9–3.13, plus 18 integration tests
+gated on a running Postgres.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sqlalchemy-adbc"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generic SQLAlchemy dialect for any ADBC driver (Flight SQL, PostgreSQL, SQLite, Snowflake, BigQuery)."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Prepares v0.3.0 — the reflection + Alembic + get_indexes release
(PRs #5, #6, #7). Three pieces:

1. CHANGELOG.md at repo root, Keep-a-Changelog format. Backfills
   0.1.0 and 0.2.0 from git log + PR bodies; drafts 0.3.0 with
   links to the PRs. Tracks in-flight work (PG types / #8) under
   Unreleased so the next version's notes are already started.

2. README status: Alpha → Beta. Beta (not GA) because:
   - Only SQLite is fully CI-exercised end-to-end; PG integration
     landed with #8 but isn't merged yet
   - Two breaking changes shipped in two weeks (TLS default in
     0.2.0, dialect name/driver swap in 0.3.0) — not a stable API
     commitment yet
   - Real-world feedback needed before claiming 1.0
   Links to CHANGELOG.md and GitHub Releases added.

3. publish.yml gets a `github-release` job that runs AFTER the
   PyPI upload succeeds (so we never advertise a version that
   failed to upload). Pulls the matching version's CHANGELOG
   section as the release body via awk, appends a `pip install`
   line with a PyPI link. No binary assets — PyPI is the
   distribution channel; duplicating wheels invites drift.

Version bumped to 0.3.0 in pyproject.toml. Tests: 89 pass, 17
skipped (PG-gated), 1 xfail — unchanged from main.

After merge: push `v0.3.0` tag → publish.yml fires → PyPI +
GitHub Release atomically.
